### PR TITLE
Create defaults

### DIFF
--- a/src/routes/flags/index.tsx
+++ b/src/routes/flags/index.tsx
@@ -446,7 +446,9 @@ export default component$(() => {
                 {t('flags.script.label@@Script')}
               </h1>
               <span class="text-sm sm:text-base pb-4">
-                {t('flags.script.description@@The resulting script that can be used to start your server. Place this file in the same location as {{fileName}}, then execute it!')}
+                {t('flags.script.description@@The resulting script that can be used to start your server. Place this file in the same location as {{fileName}}, then execute it!', {
+                  fileName: store.parsed.fileName,
+                })}
               </span>
             </OutputField>
           </div>

--- a/src/routes/flags/index.tsx
+++ b/src/routes/flags/index.tsx
@@ -181,7 +181,7 @@ export default component$(() => {
     variables: false,
     autoRestart: false,
     extraFlags: [],
-    fileName: '',
+    fileName: 'server.jar',
     flags: 'aikars',
     withResult: true,
     withFlags: false,
@@ -377,7 +377,10 @@ export default component$(() => {
                   <CardHeader>
                     {t('flags.fileName.label@@File Name')}
                   </CardHeader>
-                  <TextInput id="input" value={store.parsed.fileName} placeholder="server.jar" onInput$={(event: any) => { store.parsed.fileName = event.target!.value; setCookie(JSON.stringify(store)); }}>
+                  <TextInput id="input" value={store.parsed.fileName} defaultValue={defaultParsed.fileName} onInput$={(event: any) => {
+                    store.parsed.fileName = event.target!.value;
+                    setCookie(JSON.stringify(store));
+                  }}>
                     {t('flags.fileName.description@@The name of the file that will be used to start your server.')}
                   </TextInput>
                 </div>

--- a/src/routes/flags/index.tsx
+++ b/src/routes/flags/index.tsx
@@ -174,21 +174,23 @@ export default component$(() => {
     },
   ];
 
+  const defaultParsed = {
+    operatingSystem: '',
+    serverType: '',
+    gui: false,
+    variables: false,
+    autoRestart: false,
+    extraFlags: [],
+    fileName: '',
+    flags: 'aikars',
+    withResult: true,
+    withFlags: false,
+    memory: 0,
+  };
+
   const store: any = useStore({
     step: 1,
-    parsed: {
-      operatingSystem: '',
-      serverType: '',
-      gui: false,
-      variables: false,
-      autoRestart: false,
-      extraFlags: [],
-      fileName: '',
-      flags: 'aikars',
-      withResult: true,
-      withFlags: false,
-      memory: 0,
-    },
+    parsed: defaultParsed,
   }, { deep: true });
 
   useVisibleTask$(async () => {
@@ -212,12 +214,21 @@ export default component$(() => {
   return (
     <section class="flex mx-auto max-w-7xl px-6 min-h-[calc(100lvh-68px)]">
       <div class="w-full my-10 min-h-[60px]">
-        <h1 class="font-bold text-gray-50 text-2xl sm:text-4xl mb-2">
-          {t('flags.title@@Flags Generator')}
-        </h1>
-        <h2 class="text-gray-50 text-base sm:text-xl mb-6">
-          {t('flags.subtitle@@A simple script generator to start your Minecraft servers with optimal flags.')}
-        </h2>
+        <div class="flex justify-between flex-wrap md:flex-nowrap">
+          <div>
+            <h1 class="font-bold text-gray-50 text-2xl sm:text-4xl mb-2">
+              {t('flags.title@@Flags Generator')}
+            </h1>
+            <h2 class="text-gray-50 text-base sm:text-xl mb-6">
+              {t('flags.subtitle@@A simple script generator to start your Minecraft servers with optimal flags.')}
+            </h2>
+          </div>
+          <button class="w-full lg:w-auto" onClick$={() => {
+            store.step = 1;
+            store.parsed = defaultParsed;
+            setCookie(JSON.stringify(store));
+          }}>{t('flags.startOver@@Start over?')}</button>
+        </div>
         <div class="flex">
           <div class="flex-1">
             <button class="flex items-center justify-center sm:justify-normal gap-3 fill-current py-2 px-3 hover:bg-gray-800 transition-all w-full" onClick$={() => {


### PR DESCRIPTION
The server file name is now automatically populated so power users can fly through the config screen.

The memory slider is now given a default value, minimum, and maximum ranges depending on the server type previously selected.

A "start over" button has been added for power users to easily clear any set values.

### Still needed:
- Disable/hide config options depending on if they're available for the selected environment
- Only show flags that are compatible with the current server type