### PR TITLE
Fix MiniMessage gradient output

### DIFF
--- a/src/components/util/RGBUtils.ts
+++ b/src/components/util/RGBUtils.ts
@@ -158,6 +158,6 @@ export function generateOutput(text: string = 'SimplyMC', colors: string[] = ['#
 
     return output;
   } else {
-    return `<gradient${colors.join(':')}>${text}`;
+    return `<gradient:${colors.join(':')}>${text}`;
   }
 }


### PR DESCRIPTION
The current output of the MiniMessage format doesn't parse in-game.

This PR just adds the missing colon. Example:
```diff
- <gradient#00FFE0:#EB00FF>SimplyMC
+ <gradient:#00FFE0:#EB00FF>SimplyMC
```
https://docs.advntr.dev/minimessage/format.html#gradient