### PR TITLE
feat: add plugin updater integration for server listings

### DIFF
--- a/drizzle/migrations/0017_add_user_plugins.sql
+++ b/drizzle/migrations/0017_add_user_plugins.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD `plugins` text;

--- a/drizzle/migrations/meta/0017_snapshot.json
+++ b/drizzle/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1114 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "73335462-66c4-4ac1-9559-6f69786979cb",
+  "prevId": "1f97e7c7-1f4e-4cf6-a740-4219da90a3e7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "name": "account_provider_providerAccountId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "birdflopIpCache": {
+      "name": "birdflopIpCache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ips": {
+          "name": "ips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fetchedAt": {
+          "name": "fetchedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "presets": {
+      "name": "presets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "colorVector": {
+          "name": "colorVector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saves": {
+          "name": "saves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "pending": {
+          "name": "pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "presets_preset_unique": {
+          "name": "presets_preset_unique",
+          "columns": [
+            "preset"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "presets_userId_user_id_fk": {
+          "name": "presets_userId_user_id_fk",
+          "tableFrom": "presets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "savedPresets": {
+      "name": "savedPresets",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "presetId": {
+          "name": "presetId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "savedAt": {
+          "name": "savedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "savedPresets_userId_user_id_fk": {
+          "name": "savedPresets_userId_user_id_fk",
+          "tableFrom": "savedPresets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "savedPresets_presetId_presets_id_fk": {
+          "name": "savedPresets_presetId_presets_id_fk",
+          "tableFrom": "savedPresets",
+          "tableTo": "presets",
+          "columnsFrom": [
+            "presetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "savedPresets_userId_presetId_pk": {
+          "columns": [
+            "userId",
+            "presetId"
+          ],
+          "name": "savedPresets_userId_presetId_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "serverReports": {
+      "name": "serverReports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporterId": {
+          "name": "reporterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "serverReports_server_idx": {
+          "name": "serverReports_server_idx",
+          "columns": [
+            "serverId"
+          ],
+          "isUnique": false
+        },
+        "serverReports_resolved_idx": {
+          "name": "serverReports_resolved_idx",
+          "columns": [
+            "resolved"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "serverReports_serverId_servers_id_fk": {
+          "name": "serverReports_serverId_servers_id_fk",
+          "tableFrom": "serverReports",
+          "tableTo": "servers",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serverReports_reporterId_user_id_fk": {
+          "name": "serverReports_reporterId_user_id_fk",
+          "tableFrom": "serverReports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "serverVotes": {
+      "name": "serverVotes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "votifierDelivered": {
+          "name": "votifierDelivered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "serverVotes_server_created_idx": {
+          "name": "serverVotes_server_created_idx",
+          "columns": [
+            "serverId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "serverVotes_username_idx": {
+          "name": "serverVotes_username_idx",
+          "columns": [
+            "username"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "serverVotes_serverId_servers_id_fk": {
+          "name": "serverVotes_serverId_servers_id_fk",
+          "tableFrom": "serverVotes",
+          "tableTo": "servers",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "servers": {
+      "name": "servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shortDescription": {
+          "name": "shortDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'java'"
+        },
+        "minVersion": {
+          "name": "minVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "maxVersion": {
+          "name": "maxVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rgbPreset": {
+          "name": "rgbPreset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "javaHost": {
+          "name": "javaHost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "javaPort": {
+          "name": "javaPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bedrockHost": {
+          "name": "bedrockHost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bedrockPort": {
+          "name": "bedrockPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discord": {
+          "name": "discord",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bannerUrl": {
+          "name": "bannerUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "votifierHost": {
+          "name": "votifierHost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "votifierPort": {
+          "name": "votifierPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "votifierToken": {
+          "name": "votifierToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "featuredUntil": {
+          "name": "featuredUntil",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "plugins": {
+          "name": "plugins",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birdflopHosted": {
+          "name": "birdflopHosted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "birdflopCheckedAt": {
+          "name": "birdflopCheckedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "servers_slug_unique": {
+          "name": "servers_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "servers_owner_idx": {
+          "name": "servers_owner_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "servers_featured_idx": {
+          "name": "servers_featured_idx",
+          "columns": [
+            "featured"
+          ],
+          "isUnique": false
+        },
+        "servers_verified_idx": {
+          "name": "servers_verified_idx",
+          "columns": [
+            "verified"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "servers_ownerId_user_id_fk": {
+          "name": "servers_ownerId_user_id_fk",
+          "tableFrom": "servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "serverspulseLinks": {
+      "name": "serverspulseLinks",
+      "columns": {
+        "serverId": {
+          "name": "serverId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "listingRef": {
+          "name": "listingRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linkToken": {
+          "name": "linkToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumerName": {
+          "name": "consumerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkStatus": {
+          "name": "linkStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastCheckedAt": {
+          "name": "lastCheckedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastSuccessAt": {
+          "name": "lastSuccessAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastStateCheckAt": {
+          "name": "lastStateCheckAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastPayload": {
+          "name": "lastPayload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "serverspulseLinks_listingRef_unique": {
+          "name": "serverspulseLinks_listingRef_unique",
+          "columns": [
+            "listingRef"
+          ],
+          "isUnique": true
+        },
+        "serverspulseLinks_status_idx": {
+          "name": "serverspulseLinks_status_idx",
+          "columns": [
+            "linkStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "serverspulseLinks_serverId_servers_id_fk": {
+          "name": "serverspulseLinks_serverId_servers_id_fk",
+          "tableFrom": "serverspulseLinks",
+          "tableTo": "servers",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "privatePresets": {
+          "name": "privatePresets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugins": {
+          "name": "plugins",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verificationToken": {
+      "name": "verificationToken",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "columns": [
+            "identifier",
+            "token"
+          ],
+          "name": "verificationToken_identifier_token_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1785752722504,
       "tag": "0016_hesitant_dreadnoughts",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1785772654430,
+      "tag": "0017_add_user_plugins",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -14,6 +14,7 @@ import type {
   ServerTag,
 } from '../src/util/serverlist/constants';
 import type { PluginType } from '../src/util/plugins/ServerPlugin';
+import type { PluginsStoreType } from '../src/util/plugins/types';
 import type {
   ServersPulseLinkStatus,
   ServersPulseListing,
@@ -31,6 +32,7 @@ export const users = sqliteTable('user', {
   image: text('image'),
   privatePresets: text('privatePresets', { mode: 'json' }).$type<rgbPreset[]>(),
   settings: text('settings', { mode: 'json' }).$type<Settings>(),
+  plugins: text('plugins', { mode: 'json' }).$type<PluginsStoreType>(),
   createdAt: integer('createdAt', { mode: 'timestamp_ms' })
     .default(sql`CURRENT_TIMESTAMP`)
     .notNull(),

--- a/src/routes/plugin@auth.ts
+++ b/src/routes/plugin@auth.ts
@@ -85,7 +85,8 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
           return true;
         },
         async session({ session }) {
-          const { id, name, email, image, privatePresets } = session.user;
+          const { id, name, email, image, privatePresets, plugins } =
+            session.user;
 
           // fetch saved presets for this user
           const savedFromDB = await db
@@ -106,6 +107,7 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
               email,
               image,
               privatePresets,
+              plugins,
               savedPresets: saved,
             },
           };

--- a/src/routes/resources/plugins/index.tsx
+++ b/src/routes/resources/plugins/index.tsx
@@ -102,9 +102,14 @@ export const pluginsStoreContext =
 export default component$(() => {
   const t = inlineTranslate();
   const session = useSession();
-  const userServers = useSignal<{ id: number; name: string; slug: string }[]>(
-    []
-  );
+  const userServers = useSignal<
+    {
+      id: number;
+      name: string;
+      slug: string;
+      plugins: { [id: string]: PluginType } | null;
+    }[]
+  >([]);
 
   const notifications = useContext(NotificationContext);
   const modalRef = useSignal<HTMLDialogElement>();
@@ -151,28 +156,51 @@ export default component$(() => {
       pluginsStore.servers = dbPlugins.servers;
       pluginsStore.openServer = dbPlugins.openServer;
       pluginsStore.filter = dbPlugins.filter;
-      return;
+    } else {
+      const pluginsData = localStorage.getItem('plugins');
+      if (pluginsData) {
+        try {
+          const savedPluginsStore = JSON.parse(
+            pluginsData
+          ) as PluginsStoreType;
+          pluginsStore.servers = savedPluginsStore.servers || {};
+          pluginsStore.openServer = savedPluginsStore.openServer;
+          pluginsStore.filter = savedPluginsStore.filter;
+
+          if (session.value?.user?.id) {
+            await setUserData({ plugins: savedPluginsStore });
+          }
+        } catch (e) {
+          const notification = new Notification()
+            .setTitle('Error loading plugins')
+            .setDescription(
+              `There was an error loading your saved plugins: ${e instanceof Error ? e.message : String(e)}.`
+            )
+            .setBgColor('lum-grad-bg-red/50');
+          notifications.push(notification.toJSON());
+        }
+      }
     }
 
-    const pluginsData = localStorage.getItem('plugins');
-    if (pluginsData) {
-      try {
-        const savedPluginsStore = JSON.parse(pluginsData) as PluginsStoreType;
-        pluginsStore.servers = savedPluginsStore.servers || {};
-        pluginsStore.openServer = savedPluginsStore.openServer;
-        pluginsStore.filter = savedPluginsStore.filter;
-
-        if (session.value?.user?.id) {
-          await setUserData({ plugins: savedPluginsStore });
-        }
-      } catch (e) {
-        const notification = new Notification()
-          .setTitle('Error loading plugins')
-          .setDescription(
-            `There was an error loading your saved plugins: ${e instanceof Error ? e.message : String(e)}.`
-          )
-          .setBgColor('lum-grad-bg-red/50');
-        notifications.push(notification.toJSON());
+    // Add a tab for each owned Server List listing that isn't already
+    // represented, so plugin profiles for your servers show up automatically.
+    if (userServers.value.length > 0) {
+      const linkedServerIds = new Set(
+        Object.values(pluginsStore.servers)
+          .map((server) => server.serverId)
+          .filter((id): id is number => id !== undefined)
+      );
+      userServers.value.forEach((server) => {
+        if (linkedServerIds.has(server.id)) return;
+        if (pluginsStore.servers[server.name]) return;
+        pluginsStore.servers[server.name] = {
+          software: 'paper',
+          plugins: server.plugins || {},
+          serverId: server.id,
+        };
+      });
+      if (!pluginsStore.openServer) {
+        pluginsStore.openServer = Object.keys(pluginsStore.servers)[0];
       }
     }
   });
@@ -373,37 +401,8 @@ export default component$(() => {
                 <CurrentSoftware.icon size={20} q:slot="dropdown-before" />
               </SelectMenu>
 
-              {session.value?.user?.id && userServers.value.length > 0 && (
-                <SelectMenu
-                  id="linkedServer"
-                  onChange$={(e, el) => {
-                    const val = el.value;
-                    if (pluginsStore.openServer) {
-                      pluginsStore.servers[pluginsStore.openServer].serverId =
-                        val === 'none' ? undefined : Number(val);
-                    }
-                  }}
-                  values={[
-                    { name: 'Link listing...', value: 'none' },
-                    ...userServers.value.map((s) => ({
-                      name: s.name,
-                      value: String(s.id),
-                    })),
-                  ]}
-                  value={
-                    CurrentServer?.serverId
-                      ? String(CurrentServer.serverId)
-                      : 'none'
-                  }
-                  class="lum-bg-transparent lum-btn-p-1 rounded-lum-1"
-                  title="Link this plugin profile to your Server List listing"
-                >
-                  <Globe size={20} q:slot="dropdown-before" />
-                </SelectMenu>
-              )}
-
               <button
-                class="lum-btn lum-btn-p-1 rounded-lum-1 flex cursor-pointer items-center justify-center gap-2 border-none transition-all duration-300"
+                class="lum-btn lum-btn-p-2 rounded-lum-1 flex cursor-pointer items-center justify-center gap-2 border-none transition-all duration-300"
                 onClick$={() => {
                   if (!CurrentServer) return;
                   const exportedPlugins: { [id: string]: PluginType } = {};

--- a/src/routes/resources/plugins/index.tsx
+++ b/src/routes/resources/plugins/index.tsx
@@ -246,12 +246,12 @@ export default component$(() => {
 
       if (session.value?.user?.id) {
         await setUserData({ plugins: exportedPluginsStore });
-        if (pluginsStore.openServer && CurrentServer?.serverId) {
+        if (pluginsStore.openServer && currentServer?.serverId) {
           const currentMappedPlugins =
             exportedPluginsStore.servers[pluginsStore.openServer]?.plugins ||
             {};
           await updateServerPlugins(
-            CurrentServer.serverId,
+            currentServer.serverId,
             currentMappedPlugins
           );
         }

--- a/src/routes/resources/plugins/index.tsx
+++ b/src/routes/resources/plugins/index.tsx
@@ -40,6 +40,10 @@ import {
 } from '~/util/plugins/ServerPlugin';
 import { downloadSpigotPlugin } from '~/util/plugins/SpigotPlugin';
 import Globe from 'lucide-icons-qwik/icons/Globe';
+import { useSession } from '~/routes/plugin@auth';
+import { setUserData } from '~/util/dataUtils';
+import { getUserServers, updateServerPlugins } from '~/util/serverlist/actions';
+import type { PluginsStoreType, ServerType } from '~/util/plugins/types';
 
 const debug = true;
 
@@ -47,19 +51,6 @@ type ResolvedPluginType = {
   type: PluginSource;
   plugin?: PluginType;
   plugins?: PluginType[];
-};
-
-type ServerType = {
-  software: keyof typeof softwareOptions;
-  plugins: { [id: string]: PluginType };
-};
-
-type PluginsStoreType = {
-  servers: {
-    [serverName: string]: ServerType;
-  };
-  openServer?: string;
-  filter?: 'outdated' | PluginSource;
 };
 
 const serverDefaults: ServerType = {
@@ -110,6 +101,10 @@ export const pluginsStoreContext =
   createContextId<PluginsStoreType>('plugins-store');
 export default component$(() => {
   const t = inlineTranslate();
+  const session = useSession();
+  const userServers = useSignal<{ id: number; name: string; slug: string }[]>(
+    []
+  );
 
   const notifications = useContext(NotificationContext);
   const modalRef = useSignal<HTMLDialogElement>();
@@ -141,8 +136,24 @@ export default component$(() => {
   const CurrentSoftware = softwareOptions[CurrentServer?.software || 'paper'];
 
   // oxlint-disable-next-line qwik/no-use-visible-task
-  useVisibleTask$(() => {
+  useVisibleTask$(async () => {
     if (!isBrowser) return; // dont load plugins on the server
+    if (session.value?.user?.id) {
+      try {
+        userServers.value = await getUserServers();
+      } catch (e) {
+        console.error('Failed to load user servers:', e);
+      }
+    }
+
+    const dbPlugins = session.value?.user?.plugins;
+    if (dbPlugins?.servers && Object.keys(dbPlugins.servers).length > 0) {
+      pluginsStore.servers = dbPlugins.servers;
+      pluginsStore.openServer = dbPlugins.openServer;
+      pluginsStore.filter = dbPlugins.filter;
+      return;
+    }
+
     const pluginsData = localStorage.getItem('plugins');
     if (pluginsData) {
       try {
@@ -150,6 +161,10 @@ export default component$(() => {
         pluginsStore.servers = savedPluginsStore.servers || {};
         pluginsStore.openServer = savedPluginsStore.openServer;
         pluginsStore.filter = savedPluginsStore.filter;
+
+        if (session.value?.user?.id) {
+          await setUserData({ plugins: savedPluginsStore });
+        }
       } catch (e) {
         const notification = new Notification()
           .setTitle('Error loading plugins')
@@ -200,6 +215,19 @@ export default component$(() => {
         exportedPluginsStore.servers[server].plugins = mappedPlugins;
       });
       localStorage.setItem('plugins', JSON.stringify(exportedPluginsStore));
+
+      if (session.value?.user?.id) {
+        await setUserData({ plugins: exportedPluginsStore });
+        if (pluginsStore.openServer && CurrentServer?.serverId) {
+          const currentMappedPlugins =
+            exportedPluginsStore.servers[pluginsStore.openServer]?.plugins ||
+            {};
+          await updateServerPlugins(
+            CurrentServer.serverId,
+            currentMappedPlugins
+          );
+        }
+      }
     } catch (e) {
       const notification = new Notification()
         .setTitle('Error saving plugins')
@@ -345,8 +373,37 @@ export default component$(() => {
                 <CurrentSoftware.icon size={20} q:slot="dropdown-before" />
               </SelectMenu>
 
+              {session.value?.user?.id && userServers.value.length > 0 && (
+                <SelectMenu
+                  id="linkedServer"
+                  onChange$={(e, el) => {
+                    const val = el.value;
+                    if (pluginsStore.openServer) {
+                      pluginsStore.servers[pluginsStore.openServer].serverId =
+                        val === 'none' ? undefined : Number(val);
+                    }
+                  }}
+                  values={[
+                    { name: 'Link listing...', value: 'none' },
+                    ...userServers.value.map((s) => ({
+                      name: s.name,
+                      value: String(s.id),
+                    })),
+                  ]}
+                  value={
+                    CurrentServer?.serverId
+                      ? String(CurrentServer.serverId)
+                      : 'none'
+                  }
+                  class="lum-bg-transparent lum-btn-p-1 rounded-lum-1"
+                  title="Link this plugin profile to your Server List listing"
+                >
+                  <Globe size={20} q:slot="dropdown-before" />
+                </SelectMenu>
+              )}
+
               <button
-                class="lum-btn lum-btn-p-2 rounded-lum-1 flex cursor-pointer items-center justify-center gap-2 border-none transition-all duration-300"
+                class="lum-btn lum-btn-p-1 rounded-lum-1 flex cursor-pointer items-center justify-center gap-2 border-none transition-all duration-300"
                 onClick$={() => {
                   if (!CurrentServer) return;
                   const exportedPlugins: { [id: string]: PluginType } = {};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,17 +2,20 @@ import { AdapterUser as AdapterUserFromAuth } from '@auth/qwik/adapters';
 import { User as UserFromAuth } from '@auth/qwik';
 import { rgbPreset } from './util/rgb/presets';
 import { PublicPreset } from '../drizzle/schema';
+import type { PluginsStoreType } from './util/plugins/types';
 
 declare module '@auth/qwik' {
   interface User extends UserFromAuth {
     privatePresets?: rgbPreset[];
     savedPresets?: PublicPreset[];
+    plugins?: PluginsStoreType;
   }
 }
 
 declare module '@auth/qwik/adapters' {
   interface AdapterUser extends AdapterUserFromAuth {
     privatePresets?: rgbPreset[];
+    plugins?: PluginsStoreType;
   }
 }
 

--- a/src/util/dataUtils.ts
+++ b/src/util/dataUtils.ts
@@ -18,6 +18,7 @@ import { presetToVector } from './rgb/presets/vectorize';
 import { validatePresetSubmission } from './rgb/presets/presetValidation';
 import { isAdmin, Settings } from '~/routes/layout';
 import { Session } from '@auth/qwik';
+import type { PluginsStoreType } from './plugins/types';
 
 type names =
   | 'rgb'
@@ -220,6 +221,7 @@ export function setCookies<T extends Record<string, unknown>>(
 export const setUserData = server$(async function (data: {
   privatePresets?: rgbPreset[];
   settings?: Settings;
+  plugins?: PluginsStoreType;
 }) {
   const session = this.sharedMap.get('session') as Session | undefined;
 
@@ -232,6 +234,7 @@ export const setUserData = server$(async function (data: {
     .set({
       privatePresets: data.privatePresets,
       settings: data.settings,
+      plugins: data.plugins,
     })
     .where(eq(users.id, session.user.id))
     .returning()

--- a/src/util/serverlist/actions.ts
+++ b/src/util/serverlist/actions.ts
@@ -405,6 +405,7 @@ export const getUserServers = server$(async function () {
       id: servers.id,
       name: servers.name,
       slug: servers.slug,
+      plugins: servers.plugins,
     })
     .from(servers)
     .where(eq(servers.ownerId, session.user.id))


### PR DESCRIPTION
## Summary
- Re-adds the `users.plugins` column (schema + a fresh migration, `0017_add_user_plugins.sql`) so plugin profiles can be saved to an account instead of only `localStorage`.
- Wires the Plugin Updates page (`/resources/plugins`) up to accounts: on load it prefers the account's saved plugin data over `localStorage` (and syncs local data up on first login), and saves changes back via `setUserData`.
- Any Server List listing you own is automatically added as its own tab on load (seeded with whatever plugins are already stored on that listing), linked via `serverId`. Saving a linked tab also pushes its plugin list back to that listing via `updateServerPlugins`, which the listing's public page already renders.

This re-implements the plugin-updater/server integration from a previous attempt (`fbe520b`, reverted in `a1625b1` after it errored in dev). That attempt imported `PluginsStoreType`/`ServerType` as regular (non-type) imports from a types-only module; since this project's `tsconfig.json` sets `isolatedModules: true`, the per-file transform can't strip a cross-file type import it can't prove is type-only, so the import survived into the runtime bundle and failed to resolve at dev-server runtime. This version uses `import type` throughout, and reuses the `getUserServers`/`updateServerPlugins` actions and `ServerType`/`PluginsStoreType` types that were already committed (but unused) after the revert, plus the `useSession`/`setUserData` pattern already proven elsewhere in the app.

### Migration history sanity check
`user.plugins` was added once before (`0009_soft_krista_starr`) and dropped by the revert (`0014_true_human_torch`). By the current tip of `feat/add-serverlist`, the column does not exist, so the new `0017_add_user_plugins` migration is a fresh `ADD COLUMN`, not a duplicate. The snapshot `id`/`prevId` chain from `0008` through the new `0017` is linear with no forks.

## Test plan
- [ ] `vp install && vp dev` and confirm `/resources/plugins` loads without console errors
- [ ] Confirm logged-out behavior is unchanged (localStorage-only)
- [ ] Log in, confirm owned Server List listings appear as tabs automatically
- [ ] Add/update plugins on a linked tab, confirm they show up on the listing's public page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCYKYic3u8tJS2REWSZUnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCYKYic3u8tJS2REWSZUnR)_