### PR TITLE
feat: add server icon, edit link, and permanent tabs to plugin updater

### DIFF
--- a/src/routes/resources/plugins/index.tsx
+++ b/src/routes/resources/plugins/index.tsx
@@ -24,6 +24,8 @@ import Plus from 'lucide-icons-qwik/icons/Plus';
 import RefreshCw from 'lucide-icons-qwik/icons/RefreshCw';
 import Trash from 'lucide-icons-qwik/icons/Trash';
 import X from 'lucide-icons-qwik/icons/X';
+import { Link } from '@qwik.dev/router';
+import ExternalLink from 'lucide-icons-qwik/icons/ExternalLink';
 import { defaultDescription, generateHead } from '~/root';
 import { Label, SelectMenu, Tabs } from '@luminescent/ui-qwik';
 import PluginCard from '~/components/plugins/PluginCard';
@@ -108,6 +110,7 @@ export default component$(() => {
       name: string;
       slug: string;
       plugins: { [id: string]: PluginType } | null;
+      icon: string | null;
     }[]
   >([]);
 
@@ -300,9 +303,10 @@ export default component$(() => {
       </p>
 
       <Tabs
-        values={Object.keys(pluginsStore.servers).map((k) => ({
+        values={Object.entries(pluginsStore.servers).map(([k, v]) => ({
           name: k,
           value: k,
+          permanent: !!v.serverId,
         }))}
         value={
           pluginsStore.openServer
@@ -330,7 +334,41 @@ export default component$(() => {
             pluginsStore.openServer = serverName;
           }
         }}
-      ></Tabs>
+      >
+        {Object.keys(pluginsStore.servers).map((k, i) => {
+          const s = pluginsStore.servers[k];
+          const linked = userServers.value.find((us) => us.id === s.serverId);
+          return [
+            linked?.icon ? (
+              <img
+                key={i}
+                q:slot={`before-${k}`}
+                src={linked.icon}
+                alt={`${linked.name} icon`}
+                width={16}
+                height={16}
+                class="h-4 w-4 rounded-sm object-cover"
+                style={{ imageRendering: 'pixelated' }}
+              />
+            ) : (
+              <Globe q:slot={`before-${k}`} key={i} size={14} class="shrink-0" />
+            ),
+            ...(linked
+              ? [
+                  <Link
+                    key={`link-${i}`}
+                    q:slot={`after-${k}`}
+                    href={`/serverlist/${linked.slug}/edit`}
+                    class="lum-btn lum-bg-transparent z-10 rounded-full p-0"
+                    title={`Manage ${k} on serverlist`}
+                  >
+                    <ExternalLink size={16} />
+                  </Link>,
+                ]
+              : []),
+          ];
+        })}
+      </Tabs>
       {Object.keys(pluginsStore.servers).length < 1 && (
         <p class="text-lum-text-secondary mx-2 text-sm">
           {t(
@@ -402,7 +440,7 @@ export default component$(() => {
               </SelectMenu>
 
               <button
-                class="lum-btn lum-btn-p-2 rounded-lum-1 flex cursor-pointer items-center justify-center gap-2 border-none transition-all duration-300"
+                class="lum-btn lum-btn-p-1 rounded-lum-1 flex cursor-pointer items-center justify-center gap-2 border-none transition-all duration-300"
                 onClick$={() => {
                   if (!CurrentServer) return;
                   const exportedPlugins: { [id: string]: PluginType } = {};

--- a/src/util/serverlist/actions.ts
+++ b/src/util/serverlist/actions.ts
@@ -19,6 +19,7 @@ import {
 import { verifyTurnstile } from './turnstile';
 import { detectBirdflopHosted } from './birdflop';
 import { sendVotifierV2 } from './votifier';
+import { getServerStatus } from './status';
 import {
   claimServersPulseLink,
   isValidServersPulseLinkCode,
@@ -406,12 +407,43 @@ export const getUserServers = server$(async function () {
       name: servers.name,
       slug: servers.slug,
       plugins: servers.plugins,
+      edition: servers.edition,
+      javaHost: servers.javaHost,
+      javaPort: servers.javaPort,
+      bedrockHost: servers.bedrockHost,
+      bedrockPort: servers.bedrockPort,
     })
     .from(servers)
     .where(eq(servers.ownerId, session.user.id))
     .all();
 
-  return userServers;
+  return await Promise.all(
+    userServers.map(
+      async ({
+        edition,
+        javaHost,
+        javaPort,
+        bedrockHost,
+        bedrockPort,
+        ...rest
+      }) => {
+        let icon: string | null = null;
+        try {
+          const status = await getServerStatus({
+            edition,
+            javaHost,
+            javaPort,
+            bedrockHost,
+            bedrockPort,
+          });
+          icon = status?.icon ?? null;
+        } catch {
+          icon = null;
+        }
+        return { ...rest, icon };
+      }
+    )
+  );
 });
 
 export const updateServerPlugins = server$(async function (


### PR DESCRIPTION
## Summary
Follow-up to #245 (already merged) — restores a few UI refinements from the pre-revert plugin-store work (`fbe520b`..`71d1368`) that never made it back in:

- **Icon in tab**: `getUserServers` now pings each server via `getServerStatus` and returns its live favicon; tabs show that icon (or a `Globe` fallback) via the `before-${tab}` slot.
- **Permanent tabs**: tabs backed by a real linked server (`serverId` set) get `permanent: true` in the `Tabs` `values`, hiding the delete button so a linked tab can't be accidentally removed. `permanent` is an existing, supported prop on the installed `@luminescent/ui-qwik` `Tabs` component.
- **External link to server**: linked tabs get an `ExternalLink` button in the `after-${tab}` slot, opening that server's edit page.
- **Export button padding**: `lum-btn-p-2` → `lum-btn-p-1`, matching the rest of the toolbar row.

These were adapted rather than copied verbatim from history: the original reference commit imported `PluginsStoreType`/`ServerType` without `type` (the exact bug that got the whole feature reverted originally — see #245), and linked to a `/dashboard/servers/:slug` path that no longer exists. This version keeps the `import type` fix and points the external link at the current `/serverlist/:slug/edit` route instead.

## Test plan
- [ ] `vp install && vp dev`, open `/resources/plugins` while logged in with an owned Server List listing
- [ ] Confirm the tab shows the server's favicon (or Globe if unreachable)
- [ ] Confirm the linked tab has no delete ("x") button
- [ ] Confirm the external-link button on the tab opens `/serverlist/:slug/edit`
- [ ] Confirm the Export button's padding matches the other toolbar buttons

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CCYKYic3u8tJS2REWSZUnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCYKYic3u8tJS2REWSZUnR)_